### PR TITLE
chore: refactor shortener service to use Redis storage

### DIFF
--- a/shortener/BUILD.bazel
+++ b/shortener/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/blackhorseya/golang-101/shortener",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/storage/redix",
         "//pkg/stringx",
         "@com_github_gin_gonic_gin//:gin",
+        "@com_github_redis_go_redis_v9//:go-redis",
     ],
 )
 


### PR DESCRIPTION
- Add `pkg/storage/redix` as a dependency in `shortener/BUILD.bazel`
- Import `context` in `shortener/main.go`
- Initialize `rdb` as a global variable in `shortener/main.go`
- Create a redis client in `shortener/main.go`
- Replace `err` assignment in `shortener/main.go`